### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,7 @@
         <description lang="en">Download Movie information from www.filmweb.pl</description>
         <description lang="pl">Pobiera informacje o filmie ze strony www.filmweb.pl</description>
         <platform>all</platform>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
         <forum>http://kodi.org.pl/forum/10-XBMC---Wtyczki-pluginy/3565-filmweb-pl-scraper</forum>
         <email>regss84@gmail.com</email>
         <source>https://github.com/Regss/metadata.filmweb.pl</source>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
