### PR TITLE
brak zakodowania &

### DIFF
--- a/filmweb.xml
+++ b/filmweb.xml
@@ -446,7 +446,7 @@
             <RegExp input="$$5" output="\1" dest="4">
                 <expression>source src=&quot;([^&quot;]+)&quot; type=.video/quicktime</expression>
             </RegExp>
-            <RegExp input="$$5" output="plugin://plugin.video.youtube/?action=play_video&videoid=\1" dest="4">
+            <RegExp input="$$5" output="plugin://plugin.video.youtube/?action=play_video&amp;videoid=\1" dest="4">
                 <expression>&quot;http://www.youtube.com/v/([^&quot;]+)&quot;</expression>
             </RegExp>
             <expression />


### PR DESCRIPTION
Brak zakodowania znaku & do postaci &amp; co powoduje niezgodność z XML. W efekcie daje to nie rozpoznawanie scrapera przez TinyMediaManager'a i nie udostępnienie do wyboru przy scrapowaniu filmów. Poprawka rozwiązuje problem.
